### PR TITLE
Updated .gitignore for Godot 4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,21 @@
+# Godot 4+ specific ignores
+.godot/
+
+# Godot-specific ignores
 .import/
 *.import 
-
 .export/
+export.cfg
+export_presets.cfg
 .cache/
+
+# Imported translations (automatically generated from CSV files)
 *.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json
 
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
Mostly, this just excludes the .godot cache folder from getting tracked.

Resolves #2 