### PR TITLE
Realign Player child nodes

### DIFF
--- a/main_scene.tscn
+++ b/main_scene.tscn
@@ -1902,7 +1902,7 @@ tile_set = SubResource("TileSet_54ow2")
 [node name="Camera2D" type="Camera2D" parent="Player"]
 
 [node name="CharacterBody2D" type="CharacterBody2D" parent="Player"]
-position = Vector2(-136.36, -165.35)
+position = Vector2(1.0737, -66.0325)
 motion_mode = 1
 script = ExtResource("4_pwyh5")
 metadata/_edit_group_ = true

--- a/main_scene.tscn
+++ b/main_scene.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=8 format=4 uid="uid://bw61hcrsu2ee5"]
 
-[ext_resource type="Texture2D" uid="uid://bc7bae33s28ir" path="res://Assets/Art/CaveTiles1/CaveBG.png" id="3_debib"]
-[ext_resource type="Texture2D" uid="uid://df07d81malalj" path="res://Assets/Art/diver/diver1.png" id="3_mpcjb"]
+[ext_resource type="Texture2D" uid="uid://dl0whk8can5rx" path="res://Assets/Art/CaveTiles1/CaveBG.png" id="3_debib"]
+[ext_resource type="Texture2D" uid="uid://m3cgsjtu281v" path="res://Assets/Art/diver/diver1.png" id="3_mpcjb"]
 [ext_resource type="Script" path="res://Scripts/Player/Player.gd" id="4_pwyh5"]
-[ext_resource type="Texture2D" uid="uid://d3o5ck02o5idq" path="res://Assets/Art/CaveTiles1/CaveG.png" id="4_x3thl"]
+[ext_resource type="Texture2D" uid="uid://dimpgxeu3oakl" path="res://Assets/Art/CaveTiles1/CaveG.png" id="4_x3thl"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_mydmx"]
 texture = ExtResource("4_x3thl")
@@ -1905,12 +1905,13 @@ tile_set = SubResource("TileSet_54ow2")
 position = Vector2(-136.36, -165.35)
 motion_mode = 1
 script = ExtResource("4_pwyh5")
+metadata/_edit_group_ = true
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Player/CharacterBody2D"]
+position = Vector2(-6, -66)
 polygon = PackedVector2Array(30, 81, 20, 76, 9, 75, 1, 70, -5, 69, -10, 69, -17, 70, -20, 66, -23, 58, -18, 49, -10, 49, -4, 54, 8, 59, 8, 66, 16, 68, 23, 68, 31, 75)
 
 [node name="Sprite2D" type="Sprite2D" parent="Player/CharacterBody2D"]
-position = Vector2(6, 66)
 scale = Vector2(0.2, 0.2)
 texture = ExtResource("3_mpcjb")
 
@@ -1920,11 +1921,13 @@ anchors_preset = 0
 
 [node name="Oxygen" type="ProgressBar" parent="HUD"]
 visible = false
+layout_mode = 0
 offset_right = 4.0
 offset_bottom = 27.0
 
 [node name="Weight" type="ProgressBar" parent="HUD"]
 visible = false
+layout_mode = 0
 offset_right = 4.0
 offset_bottom = 27.0
 


### PR DESCRIPTION
Realigns the Sprite2D and the CollisionPolygon2D with the CharacterBody2D and groups them to prevent future misalignment.

Resolves #5 