### PR TITLE
added *.import to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .godot/
 
 # Godot-specific ignores
+*.import
 .import/
 export.cfg
 export_presets.cfg


### PR DESCRIPTION
Added ``*.import`` to the .gitignore to prevent all the ``image_name.png.import`` files from being tracked.

Closes #8